### PR TITLE
[IN-1226] Adjust concurrency for TF workflow

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -34,7 +34,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ${{ github.repository }}-terraform # ensure only one instance is run
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }} 
 
 env:
   TF_VAR_remote_state_role_arn: ${{ inputs.aws_remote_role_arn }}


### PR DESCRIPTION
Right now, we are limited to one TF run regardless of branch.  This will enable one TF run per branch.

References

- https://stackoverflow.com/questions/70928424/limit-github-action-workflow-concurrency-on-push-and-pull-request
- https://docs.github.com/en/actions/using-jobs/using-concurrency
- https://docs.github.com/en/actions/learn-github-actions/contexts