### PR TITLE
[XMT] Add reusable workflow that creates github access token using github app

### DIFF
--- a/.github/workflows/create_bot_access_token.yml
+++ b/.github/workflows/create_bot_access_token.yml
@@ -1,0 +1,31 @@
+name: Create Bot Access Token
+
+on:
+  workflow_call:
+    outputs:
+      token:
+        description: "Github Access Token"
+        value: ${{ jobs.create_bot_access_token.outputs.token }}
+
+jobs:
+  create_bot_access_token:
+    runs-on: ubuntu-latest
+    outputs:
+      token: ${{ steps.app-token.outputs.token }}
+    steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          # required
+          app-id: ${{ vars.WORKFLOW_TOKEN_CREATION_APP_ID }}
+          private-key: ${{ secrets.WORKFLOW_TOKEN_CREATION_APP_PRIVATE_KEY }}
+      - name: Get GitHub App User ID
+        id: get-user-id
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+      - name: 🤖 Set Git User to Automation Bot
+        run: |
+          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
+          git config --global user.password ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
- This PR adds a reusable workflow that creates a Github Access Token using the MT Automation GitHub App. The MT Automation App will be used in different workflows and it will be allowed to bypass repo permissions to push packages, push to the default branch, open PRs, among other cases.

- This is needed so we can retire the mt-engineering GitHub user